### PR TITLE
Fix name cleaning

### DIFF
--- a/dl.js
+++ b/dl.js
@@ -10,17 +10,13 @@ const jar = request.jar();
 
 jar.setCookie(sessionCookie, skillshareUrl);
 
-const cleanName = name => {
-  if (typeof name === 'number') {
-    return name;
-  } else {
-    return name
+const cleanName = name => 
+  name
+    .toString()
     .toLowerCase()
     .replace(/[^a-z0-9]+/gi, " ")
     .trim()
     .replace(/ /gi, "_");
-  }
-}
 
 async function getVideoInfo(accountId, policyKey, session) {
   const match = session.video_mid_thumbnail_url.match(/\/thumbnails\/(\d+)\//);

--- a/dl.js
+++ b/dl.js
@@ -10,12 +10,17 @@ const jar = request.jar();
 
 jar.setCookie(sessionCookie, skillshareUrl);
 
-const cleanName = name =>
-  name
+const cleanName = name => {
+  if (typeof name === 'number') {
+    return name;
+  } else {
+    return name
     .toLowerCase()
     .replace(/[^a-z0-9]+/gi, " ")
     .trim()
     .replace(/ /gi, "_");
+  }
+}
 
 async function getVideoInfo(accountId, policyKey, session) {
   const match = session.video_mid_thumbnail_url.match(/\/thumbnails\/(\d+)\//);

--- a/dl.js
+++ b/dl.js
@@ -10,7 +10,7 @@ const jar = request.jar();
 
 jar.setCookie(sessionCookie, skillshareUrl);
 
-const cleanName = name => 
+const cleanName = name =>
   name
     .toString()
     .toLowerCase()


### PR DESCRIPTION
Fixes an issue for videos with only a number in their title.

Error description:
```(node:26932) UnhandledPromiseRejectionWarning: TypeError: name.toLowerCase is not a function
    at cleanName (C:\Users\User\Desktop\skillshare\skillshare-downloader\dl.js:16:6)
    at C:\Users\User\Desktop\skillshare\skillshare-downloader\dl.js:85:34
    at process._tickCallback (internal/process/next_tick.js:68:7)
(node:26932) UnhandledPromiseRejectionWarning: Unhandled promise rejection. 
This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)